### PR TITLE
Remove call to busted pyopenstates.locate_legislators API

### DIFF
--- a/call_server/political_data/countries/us.py
+++ b/call_server/political_data/countries/us.py
@@ -441,7 +441,7 @@ class USDataProvider(DataProvider):
         if not (location.latitude and location.longitude):
             raise LocationError('USDataProvider.get_state_legislators requires location with lat/lon')    
 
-        legislators = pyopenstates.locate_legislators(location.latitude, location.longitude)
+        legislators = pyopenstates.search_legislators(state=location.state)
 
         # save results individually in local cache
         for leg in legislators:


### PR DESCRIPTION
https://openstates.org/api/v1/legislators/geo/ is currently down, which is breaking lookups. I switched to doing a state search via https://openstates.org/api/v1/legislators/. Not sure if that will return the correct data in all cases, but it's working for me 🤷‍♂️ .