### PR TITLE
Upgrade OpenStates API to v2

### DIFF
--- a/OPEN_DATA_SOURCES.md
+++ b/OPEN_DATA_SOURCES.md
@@ -9,7 +9,7 @@ Data is provided under the original license of the data provider.
 
 * US Congress contact data from [UnitedStates/congress](https://github.com/unitedstates/congress), public domain
 * US Governors contact data scraped from [National Governors Association](https://github.com/spacedogXYZ/us_governors_contact), all rights reserved
-* US States legislature contact data from [OpenStates API](http://docs.openstates.org/en/latest/api/)
+* US States legislature contact data from [OpenStates API](https://docs.openstates.org/en/latest/api/v2/)
 
 * Canadan Member of Parliament contact data from [Represent](http://represent.opennorth.ca), licenses available from [OpenNorth](https://github.com/opennorth/represent-canada-data)
 

--- a/call_server/config.py
+++ b/call_server/config.py
@@ -1,7 +1,5 @@
 import os
 import twilio.rest
-import pyopenstates
-
 
 class DefaultConfig(object):
     PROJECT = 'CallPower'
@@ -56,7 +54,6 @@ class DefaultConfig(object):
     OPENSTATES_API_KEY = os.environ.get('OPENSTATES_API_KEY')
     if not OPENSTATES_API_KEY:
         OPENSTATES_API_KEY = os.environ.get('OPENSTATES_API_KEY')
-    pyopenstates.set_api_key(OPENSTATES_API_KEY)
 
     LOG_PHONE_NUMBERS = True
 

--- a/call_server/political_data/adapters.py
+++ b/call_server/political_data/adapters.py
@@ -127,7 +127,9 @@ class OpenStatesData(DataAdapter):
                 chamber = None
                 district = None
 
-        if chamber == "upper":
+        if 'title' in data:
+            adapted['title'] = data['title']
+        elif chamber == "upper":
             adapted['title'] = 'Senator'
         else:
             adapted['title'] = 'Representative'

--- a/call_server/political_data/adapters.py
+++ b/call_server/political_data/adapters.py
@@ -117,10 +117,10 @@ class OpenStatesData(DataAdapter):
             'uid': data.get('id')
         }
         if 'chamber' in data:
-            if type(data['chamber'] == dict):
+            if type(data['chamber']) == dict:
                 chamber = data['chamber'][0]['organization']['classification']
                 district = data['chamber'][0]['post']['label']
-            elif type(data['chamber'] == str):
+            elif type(data['chamber']) == str:
                 chamber = data['chamber']
                 district = data.get('district', '')
             else:
@@ -203,8 +203,8 @@ class OpenStatesData(DataAdapter):
         # so we can iterate more cleanly
         offices_dict = defaultdict(dict)
         for c in data.get('contactDetails', []):
-            offices[c['note']][c['type']] = c['value']
-            offices[c['note']]['name'] = c['note']
+            offices_dict[c['note']][c['type']] = c['value']
+            offices_dict[c['note']]['name'] = c['note']
 
         office_list = []
         for office in offices_dict.values():

--- a/call_server/political_data/adapters.py
+++ b/call_server/political_data/adapters.py
@@ -1,5 +1,6 @@
 # translate country specific data to campaign model field names
 
+from collections import defaultdict
 
 def adapt_by_key(key):
     if key.startswith("us:bioguide"):
@@ -109,7 +110,51 @@ class UnitedStatesData(DataAdapter):
 
 class OpenStatesData(DataAdapter):
     def target(self, data):
+        if data.get('leg_id'):
+            return self.target_legacy(data)
 
+        adapted = {
+            'uid': data.get('id')
+        }
+        if 'chamber' in data:
+            if type(data['chamber'] == dict):
+                chamber = data['chamber'][0]['organization']['classification']
+                district = data['chamber'][0]['post']['label']
+            elif type(data['chamber'] == str):
+                chamber = data['chamber']
+                district = data.get('district', '')
+            else:
+                chamber = None
+                district = None
+
+        if chamber == "upper":
+            adapted['title'] = 'Senator'
+        else:
+            adapted['title'] = 'Representative'
+
+        adapted['district'] = district
+
+        if data.get('name'):
+            adapted['name'] = data['name']
+        elif 'givenName' in data and 'familyName' in data:
+            adapted['name'] = u'{givenName} {familyName}'.format(**data)
+
+        # filter contact details for voice type
+        if 'contactDetails' in data:
+            office_phones = [d for d in data['contactDetails'] if d['type'] == 'voice']
+            # default to capitol office
+            for office in office_phones:
+                if office.get('note') == 'Capitol Office':
+                    adapted['number'] = office.get('value', '')
+            # if none, try first
+            if not 'number' in adapted:
+                adapted['number'] = office_phones[0].get('value', '')
+                # fallback to none
+
+        return adapted
+
+    def target_legacy(self, data):
+        """ adapter for OpenStates v1 API data"""
         adapted = {
             'uid': data.get('leg_id', '')
         }
@@ -149,6 +194,33 @@ class OpenStatesData(DataAdapter):
         return adapted
 
     def offices(self, data):
+        if data.get('leg_id'):
+            return self.offices_legacy(data)
+
+        # merge contactDetails list of dicts by note
+        # so we can iterate more cleanly
+        offices_dict = defaultdict(dict)
+        for c in data.get('contactDetails', []):
+            offices[c['note']][c['type']] = c['value']
+            offices[c['note']]['name'] = c['note']
+
+        office_list = []
+        for office in offices_dict.values():
+            office_name = office.get('name', '')
+            office_name = office_name.replace('Office', '').replace('office', '')
+            if '#' in office_name:
+                office_name = office_name.split('#')[0]
+
+            office_list.append({
+                'name': office_name,
+                'address': office.get('address', ''),
+                'number': office.get('voice', ''),
+                'type': office.get('name', '')
+            })
+        return office_list
+
+    def offices_legacy(self, data):
+        """ adapter for OpenStates v1 API data"""
         office_list = []
         for office in data.get('offices', []):
             if office.get('type') == 'capitol':

--- a/call_server/political_data/countries/us.py
+++ b/call_server/political_data/countries/us.py
@@ -555,6 +555,7 @@ class USDataProvider(DataProvider):
 
             chamber_classification = leg['chamber'][0]['organization']['classification']
             district_label = leg['chamber'][0]['post']['label']
+            post_division = leg['chamber'][0]['post']['division']['id']
             post_state = ocd_field(post_division, 'state').upper()
             role_title = leg['chamber'][0]['post']['role']
 

--- a/call_server/political_data/countries/us.py
+++ b/call_server/political_data/countries/us.py
@@ -214,9 +214,8 @@ class USCampaignType_State(USCampaignType):
 
     def _filter_legislators(self, legislators, campaign_region=None):
         for legislator in legislators:
-            is_active = legislator['active']
             in_state = campaign_region is None or legislator['state'].upper() == campaign_region.upper()
-            if is_active and in_state:
+            if in_state:
                 yield legislator
 
 

--- a/call_server/political_data/countries/us.py
+++ b/call_server/political_data/countries/us.py
@@ -7,6 +7,7 @@ from . import DataProvider, CampaignType
 from ..geocode import Geocoder, LocationError
 from ..constants import US_STATES
 from ...campaign.constants import (LOCATION_POSTAL, LOCATION_ADDRESS, LOCATION_LATLON)
+from ...utils import ocd_field
 
 import os
 import random
@@ -467,6 +468,10 @@ class USDataProvider(DataProvider):
                     chamber: currentMemberships(classification:["upper", "lower"]) {
                       post {
                         label
+                        role
+                        division {
+                          id
+                        }
                       }
                       organization {
                         name
@@ -491,8 +496,14 @@ class USDataProvider(DataProvider):
 
             chamber_classification = leg['chamber'][0]['organization']['classification']
             district_label = leg['chamber'][0]['post']['label']
+            post_division = leg['chamber'][0]['post']['division']['id']
+            post_state = ocd_field(post_division, 'state').upper()
+            role_title = leg['chamber'][0]['post']['role']
+
             leg['chamber'] = chamber_classification
+            leg['state'] = post_state
             leg['district'] = district_label
+            leg['title'] = role_title
 
             key = self.KEY_OPENSTATES.format(id=leg['id'])
             leg['cache_key'] = key
@@ -522,6 +533,10 @@ class USDataProvider(DataProvider):
                   chamber: currentMemberships(classification:["upper", "lower"]) {
                       post {
                         label
+                        role
+                        division {
+                          id
+                        }
                       }
                       organization {
                         name
@@ -540,8 +555,14 @@ class USDataProvider(DataProvider):
 
             chamber_classification = leg['chamber'][0]['organization']['classification']
             district_label = leg['chamber'][0]['post']['label']
+            post_state = ocd_field(post_division, 'state').upper()
+            role_title = leg['chamber'][0]['post']['role']
+
             leg['chamber'] = chamber_classification
+            leg['state'] = post_state
             leg['district'] = district_label
+            leg['title'] = role_title
+
             leg['cache_key'] = key
             self.cache_set(key, leg)
         return leg

--- a/call_server/political_data/data_cache.py
+++ b/call_server/political_data/data_cache.py
@@ -1,7 +1,7 @@
 from flask import current_app
 from ..extensions import cache
 from ..political_data.adapters import adapt_by_key
-import pyopenstates
+from countries.us import USDataProvider
 
 def check_political_data_cache(key, cache=cache):
     adapter = adapt_by_key(key)
@@ -13,7 +13,7 @@ def check_political_data_cache(key, cache=cache):
         # but may be available over external APIs
         if adapted_key.startswith("us_state:openstates"):
             leg_id = key.split(':')[-1]
-            leg = pyopenstates.get_legislator(leg_id)
+            leg = USDataProvider(cache).get_state_legid(leg_id)
             leg['cache_key'] = key
             cache.set(key, leg)
             cached_obj = leg

--- a/call_server/utils.py
+++ b/call_server/utils.py
@@ -107,6 +107,17 @@ def ignore_accents(string):
     return unicodedata.normalize('NFD', string).encode('ascii', 'ignore')
 
 
+def ocd_field(ocd_data, field):
+    """ Takes an OpenCivicData string, splits it by / and looks for a labeled field"""
+    parts = ocd_data.split('/')
+    for p in parts:
+        if ":" in p:
+            label,value = p.split(':')
+            if label == field:
+                return value
+    return ''
+
+
 class OrderedDictYAMLLoader(yaml.Loader):
     """
     A YAML loader that loads mappings into ordered dictionaries.

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -28,6 +28,7 @@ blinker==1.3
 decorator==3.4.2
 flask-talisman==0.3.2
 geopy==1.11.0
+graphqlclient==0.2.4
 httplib2==0.8
 infinity==1.3
 intervals==0.3.1
@@ -45,7 +46,6 @@ pytz==2017.2
 requests>=2.20.0
 six==1.10.0
 speaklater==1.3
-pyopenstates==1.1.0
 twilio==6.4.2
 unittest2==0.5.1
 validators==0.7

--- a/tests/test_us_state_data.py
+++ b/tests/test_us_state_data.py
@@ -45,12 +45,10 @@ class TestUSStateData(BaseTestCase):
         house_rep = self.us_data.get_uid(uids[0])
         self.assertEqual(house_rep['chamber'], 'lower')
         self.assertEqual(house_rep['state'].upper(), 'CA')
-        self.assertEqual(house_rep['active'], True)
 
         senator = self.us_data.get_uid(uids[1])
         self.assertEqual(senator['chamber'], 'upper')
         self.assertEqual(senator['state'].upper(), 'CA')
-        self.assertEqual(senator['active'], True)
 
     def test_locate_targets_lower_only(self):
         self.STATE_CAMPAIGN.campaign_subtype = 'lower'
@@ -60,8 +58,6 @@ class TestUSStateData(BaseTestCase):
         house_rep = self.us_data.get_uid(uids[0])
         self.assertEqual(house_rep['chamber'], 'lower')
         self.assertEqual(house_rep['state'].upper(), 'CA')
-        self.assertEqual(house_rep['active'], True)
-
     def test_locate_targets_upper_only(self):
         self.STATE_CAMPAIGN.campaign_subtype = 'upper'
         uids = locate_targets(self.mock_location, self.STATE_CAMPAIGN, cache=self.mock_cache)
@@ -70,7 +66,6 @@ class TestUSStateData(BaseTestCase):
         senator = self.us_data.get_uid(uids[0])
         self.assertEqual(senator['chamber'], 'upper')
         self.assertEqual(senator['state'].upper(), 'CA')
-        self.assertEqual(senator['active'], True)
 
     def test_locate_targets_ordered_lower_first(self):
         self.STATE_CAMPAIGN.campaign_subtype = 'both'


### PR DESCRIPTION
The old API no longer provides legislator IDs for newly elected officials.

Switching to use the GraphQL API lets us continue to connect callers with their state legislators.