### PR TITLE
Add "legislature" to chamber filters

### DIFF
--- a/call_server/political_data/countries/us.py
+++ b/call_server/political_data/countries/us.py
@@ -465,7 +465,7 @@ class USDataProvider(DataProvider):
                     name
                     givenName
                     familyName
-                    chamber: currentMemberships(classification:["upper", "lower"]) {
+                    chamber: currentMemberships(classification:["upper", "lower", "legislature"]) {
                       post {
                         label
                         role


### PR DESCRIPTION
Nebraska only has one legislative chamber, neither "upper" or "lower". The list of classification filters for a legislator's chamber should include `"legislature"` to accommodate this.